### PR TITLE
Fix "speeds" data type

### DIFF
--- a/src/main/java/com/obones/binding/airzone/internal/api/model/AirZoneHvacZone.java
+++ b/src/main/java/com/obones/binding/airzone/internal/api/model/AirZoneHvacZone.java
@@ -141,8 +141,11 @@ public class AirZoneHvacZone {
     };
 
     public int[] getSpeeds() {
+        if (speeds == null) {
+            return new int[0];
+        }
         int[] value = new int[speeds + 1];
-        for (int i=0; i <= speeds; i++) {
+        for (int i = 0; i < value.length; i++) {
             value[i] = i;
         }
         return value;

--- a/src/main/java/com/obones/binding/airzone/internal/api/model/AirZoneHvacZone.java
+++ b/src/main/java/com/obones/binding/airzone/internal/api/model/AirZoneHvacZone.java
@@ -44,7 +44,7 @@ public class AirZoneHvacZone {
     private double temp_step;
     private int @Nullable [] modes = {};
     private int mode;
-    private int[] speeds = {};
+    private int speeds;
     private int speed;
     private int coldStage;
     private int heatStage;
@@ -141,7 +141,11 @@ public class AirZoneHvacZone {
     };
 
     public int[] getSpeeds() {
-        return speeds;
+        int[] value = new int[speeds + 1];
+        for (int i=0; i <= speeds; i++) {
+            value[i] = i;
+        }
+        return value;
     }
 
     public int getSpeed() {


### PR DESCRIPTION
According to the [AirZone Local API docs](https://developers.airzonecloud.com/docs/local-api/#post-/hvac), the "speeds" key is an integer, not an array.

Fixes https://github.com/obones/openhab-binding-airzone/issues/1